### PR TITLE
Add boto3 library to support s3 plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN set -ex \
     && pip install pyOpenSSL \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
+    && pip install boto3 \
     && pip install apache-airflow[crypto,celery,postgres,jdbc,s3]==$AIRFLOW_VERSION \
     && pip install celery[redis] \
     && pip install psycopg2-binary \


### PR DESCRIPTION
S3 based logging is not working since its dependency boto3 is not installed.